### PR TITLE
Bugfix to keep the start value always positive in the call to native substr

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ substr-polyfill
 
 Modular polyfill for substr(-1) for IE browsers.
 
-Credit goes to MDN for the polyfill code.  This repo is here so npm and bower can include it easily.
+Credit goes to MDN for the polyfill code and to [mulllhausen](https://github.com/mulllhausen) for a bugfix.  This repo is here so npm and bower can include it easily.
 
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
 

--- a/index.js
+++ b/index.js
@@ -9,9 +9,15 @@ if ('ab'.substr(-1) != 'b')
    */
   module.exports = String.prototype.substr = function(substr) {
     return function(start, length) {
-      // did we get a negative start, calculate how much it is
-      // from the beginning of the string
-      if (start < 0) start = this.length + start;
+      // did we get a negative start?
+      if (start < 0) {
+        // calculate how much it is from the beginning of the string
+        start = this.length + start;
+
+        // if start is still negative then set it to the beginning of
+        // the string
+        if (start < 0) start = 0;
+      }
       
       // call the original function
       return substr.call(this, start, length);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "substr-polyfill",
-  "version": "0.0.2",
-  "description": "Modular polyfill for substr(-1) for IE browsers.  Respectfully copied from MDN and added to a module.",
+  "version": "0.0.3",
+  "description": "Modular polyfill for substr(-1) for IE browsers.  Respectfully modified from MDN and added to a module.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
IE cannot accept negative start values in its native `substr()` method. This commit makes sure the start value is never negative in the native call.